### PR TITLE
fix: order of module while creation

### DIFF
--- a/backend/src/services/moduleService.ts
+++ b/backend/src/services/moduleService.ts
@@ -18,7 +18,7 @@ class ModuleService {
     const lastModule = await Module.findOne({ courseRef: courseRef }).sort({
       order: -1,
     });
-    const order = !lastModule ? 0 : lastModule.order + 1;
+    const order = !lastModule ? 1 : lastModule.order + 1;
 
     const module = await Module.create({
       courseRef: courseRef,


### PR DESCRIPTION
Instead of 0, module order starts from 1 now

Refs: #BJET-99